### PR TITLE
Fix/position errors linked list

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -36,7 +36,7 @@ class LinkedList
   def to_string
     #? works when head is nil ?
     if (head == nil)
-      p "nil"
+      return
     else
       output = []
       last_node = head
@@ -79,7 +79,7 @@ class LinkedList
   def find(position, amt)
     #todo = error ~undef method next_node for nil when finding position higher than length
     if (head == nil)
-      p "nil"
+      return
     else
       output = []
       current_node = head
@@ -98,7 +98,7 @@ class LinkedList
 
   def includes?(beat)
     if (head == nil)
-      puts "nil"
+      return
     end
     current_node = head
     has_beat = false
@@ -116,14 +116,16 @@ class LinkedList
   end
 
   def pop
-    #todo = error ~undef method next_node for nil when pop called on nil-head
-    #? pop returns nil whan ran
+    #? pop returns nil when called
     current_node = head
     prev_node = nil
-    if (head.next_node == nil)
+    if (head == nil)
+      return
+    elsif (head.next_node == nil)
       @head = nil
       return
     end
+
     while (current_node.next_node != nil)
       prev_node = current_node
       current_node = current_node.next_node
@@ -133,9 +135,8 @@ class LinkedList
 
 end
 
-require "pry" ; binding.pry
 # list = LinkedList.new
-#     list.append("deep")
+#   list.append("deep")
 #     list.append("woo")
 #     list.append("shi")
 #     list.append("shu")
@@ -143,3 +144,4 @@ require "pry" ; binding.pry
 
 #     list.pop
 #     list.pop
+#require "pry" ; binding.pry

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -60,9 +60,14 @@ class LinkedList
   end
 
   def insert(position, data)
-    #todo = error ~undef method next_node for nil when position higher than list length
     if (head == nil)
       @head = Node.new(data)
+    elsif (position > self.count)
+      return
+    elsif (position <= 0)
+      old_head = head
+      @head = Node.new(data)
+      head.next_node = old_head
     else
       current_node = head
       node_count = 1
@@ -135,12 +140,12 @@ class LinkedList
 
 end
 
-# list = LinkedList.new
-#   list.append("deep")
-#     list.append("woo")
-#     list.append("shi")
-#     list.append("shu")
-#     list.append("blop")
+list = LinkedList.new
+  list.append("deep")
+    list.append("woo")
+    list.append("shi")
+    list.append("shu")
+    list.append("blop")
 
 #     list.pop
 #     list.pop

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -34,7 +34,6 @@ class LinkedList
   end
 
   def to_string
-    #? works when head is nil ?
     if (head == nil)
       return
     else
@@ -81,9 +80,11 @@ class LinkedList
     end
   end
 
-  def find(position, amt)
-    #todo = error ~undef method next_node for nil when finding position higher than length
+  def find(position, number_of_beats)
     if (head == nil)
+      return
+    elsif (position >= self.count) ||
+          (self.count - position < number_of_beats)
       return
     else
       output = []
@@ -93,7 +94,7 @@ class LinkedList
         current_node = current_node.next_node
         node_count += 1
       end
-      amt.times do 
+      number_of_beats.times do 
       output << current_node.data
       current_node = current_node.next_node
       end
@@ -142,10 +143,10 @@ end
 
 list = LinkedList.new
   list.append("deep")
-    list.append("woo")
-    list.append("shi")
-    list.append("shu")
-    list.append("blop")
+  list.append("woo")
+  list.append("shi")
+  list.append("shu")
+  list.append("blop")
 
 #     list.pop
 #     list.pop

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe LinkedList do
     expect(list.to_string).to eq("woo bop zap pish")
   end
 
-  it 'can handle insert with over large position number' do
+  it 'can handle insert with over-large position number' do
     list = LinkedList.new
     list.append("plop")
     list.append("suu")
@@ -135,9 +135,25 @@ RSpec.describe LinkedList do
 
     expect(list.find(2, 1)).to eq("shi")
     expect(list.find(1, 3)).to eq("woo shi shu")
+    expect(list.find(0, 5)).to eq("deep woo shi shu blop")
+    expect(list.find(4, 1)).to eq("blop")
   end
 
-  it 'check if node is included' do
+  it 'can handle find with out-of-range arguments' do
+    list = LinkedList.new
+    list.append("bonk")
+    list.append("blip")
+    list.append("zip")
+    list.append("biff")
+    list.append("bap")
+
+    expect(list.find(7, 1)).to eq(nil)
+    expect(list.find(2, 13)).to eq(nil)
+    expect(list.find(9, 23)).to eq(nil)
+    expect(list.find(0, 6)).to eq(nil)
+  end
+
+  it 'checks if node is included' do
     list = LinkedList.new
     list.append("deep")
     list.append("woo")

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -93,6 +93,38 @@ RSpec.describe LinkedList do
     expect(list.to_string).to eq("dop woo plop suu")
   end
 
+  it 'can insert a node to the end' do
+    list = LinkedList.new
+    list.append("bop")
+    list.append("zap")
+    list.append("pish")
+    list.insert(3, "woo")
+
+    expect(list.to_string).to eq("bop zap pish woo")
+  end
+
+  it 'can insert a node to the head' do
+    list = LinkedList.new
+    list.append("bop")
+    list.append("zap")
+    list.append("pish")
+    list.insert(0, "woo")
+
+    expect(list.to_string).to eq("woo bop zap pish")
+  end
+
+  it 'can handle insert with over large position number' do
+    list = LinkedList.new
+    list.append("plop")
+    list.append("suu")
+    list.append("dop")
+    list.insert(22, "waaat")
+
+    expect(list.to_string).to eq("plop suu dop")
+  end
+
+# ===== Tests for Find, Includes and Pop  =====
+
   it 'can find a node and return it' do
     list = LinkedList.new
     list.append("deep")

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -133,13 +133,23 @@ RSpec.describe LinkedList do
     expect(list.to_string).to eq("deep woo shi")
   end
 
+  it 'will call pop on empty head without error' do
+    list = LinkedList.new
+    list.append("deep")
+
+    list.pop
+    list.pop
+
+    expect(list.count).to eq(0)
+  end
+
   it 'can pop node with only a head' do
     list = LinkedList.new
     list.append("deep")
 
     list.pop
 
-    expect(list.to_string).to eq("nil")
+    expect(list.to_string).to eq(nil)
   end
 
 end


### PR DESCRIPTION
pop will now return 'nil' when called on an empty head. List and insert will now return 'nil' when they are passed arguments that will exceed the length of the LinkedList.